### PR TITLE
Install python-magic package on setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     include_package_data=True,
-    install_requires=['requests']
+    install_requires=[
+        'requests',
+        'python-magic'
+    ]
 )


### PR DESCRIPTION
Hey guys, 

I noticed that installing `thehive4py` from PyPI doesn't let you use the client, because `python-magic` package is missing in the `setup.py`. The error message I receive is:

```
...
    from thehive4py.api import TheHiveApi
  File "/home/ilya/thehive-env/lib/python3.5/site-packages/thehive4py/api.py", line 8, in <module>
    import magic
ImportError: No module named 'magic'
```

Same for python 2.7:
```
...
    from thehive4py.api import TheHiveApi
  File "/home/ilya/.local/share/virtualenvs/thehive-LPUGdsMD/local/lib/python2.7/site-packages/thehive4py/api.py", line 8, in <module>
    import magic
ImportError: No module named magic
```

This PR should resolve the issue.