### PR TITLE
fix default severity level of an alert

### DIFF
--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -155,7 +155,7 @@ class Alert(JSONSerializable):
             attributes = attributes['json']
 
         self.tlp = attributes.get('tlp', 2)
-        self.severity = attributes.get('severity', 3)
+        self.severity = attributes.get('severity', 2)
         self.date = attributes.get('date', int(time.time()) * 1000)
         self.tags = attributes.get('tags', [])
         self.caseTemplate = attributes.get('caseTemplate', None)


### PR DESCRIPTION
The default severity is mentioned to default `2` in the [official API documentation](https://github.com/CERT-BDF/TheHiveDocs/blob/master/api/alert.md#model-definition), not `3`.
This also makes it consistent with the default value for a case, which is `2` as well.