### PR TITLE
Case helper

### DIFF
--- a/samples/test-case-create__case-helper.py
+++ b/samples/test-case-create__case-helper.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import time
+
+from thehive4py.api import TheHiveApi
+from thehive4py.models import CaseTask
+
+thehive = TheHiveApi('http://127.0.0.1:9000', 'username', 'password', {'http': '', 'https': ''})
+
+
+# Prepare the sample case
+tasks = [
+    CaseTask(title='Tracking'),
+    CaseTask(title='Communication'),
+    CaseTask(title='Investigation', status='Waiting', flag=True)
+]
+# tasks = []
+
+# Create the case
+print('Create Case')
+print('-----------------------------')
+case = thehive.case.create(title='From TheHive4Py', description='N/A', tlp=3, flag=True,
+                           tags=['TheHive4Py', 'sample'], tasks=tasks)
+
+# Print the details of the created case
+print(case.jsonify())
+
+# Add a new task to the created case
+print('Add a task {}'.format(case.id))
+print('-----------------------------')
+response = thehive.create_case_task(case.id, CaseTask(
+    title='Yet Another Task',
+    status='InProgress',
+    owner='nabil',
+    flag=True,
+    startDate=int(time.time())*1000))
+if response.status_code == 201:
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    print('')
+else:
+    print('ko: {}/{}'.format(response.status_code, response.text))

--- a/samples/test-case-create__case-helper.py
+++ b/samples/test-case-create__case-helper.py
@@ -5,9 +5,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+import sys
 import time
 
 from thehive4py.api import TheHiveApi
+from thehive4py.exceptions import CaseException
 from thehive4py.models import CaseTask
 
 thehive = TheHiveApi('http://127.0.0.1:9000', 'username', 'password', {'http': '', 'https': ''})
@@ -24,8 +26,13 @@ tasks = [
 # Create the case
 print('Create Case')
 print('-----------------------------')
-case = thehive.case.create(title='From TheHive4Py', description='N/A', tlp=3, flag=True,
+case = None
+try:
+    case = thehive.case.create(title='From TheHive4Py', description='N/A', tlp=3, flag=True,
                            tags=['TheHive4Py', 'sample'], tasks=tasks)
+except CaseException as e:
+    print("Error creating case. {}".format(e))
+    sys.exit(1)
 
 # Print the details of the created case
 print(case.jsonify())

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,0 +1,39 @@
+import mock
+
+from thehive4py.api import TheHiveApi
+
+
+@mock.patch('thehive4py.api.requests.get')
+def test_get_case(mock_get):
+    thehive = TheHiveApi('http://127.0.0.1:9000', 'username', 'password', {'http': '', 'https': ''})
+
+    test_id = 'AV55EOIsPQ_zDQrlj4a9'
+    test_json = {
+        '_type': 'case',
+        'caseId': 5,
+        'createdAt': 1505269703195,
+        'createdBy': 'username',
+        'customFields': {},
+        'description': 'test description',
+        'flag': False,
+        'id': test_id,
+        'metrics': {},
+        'owner': 'username',
+        'severity': 2,
+        'startDate': 1505269703000,
+        'status': 'Open',
+        'tags': [],
+        'title': 'test case',
+        'tlp': 2,
+        'user': 'username'
+    }
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = test_json
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    case = thehive.case(test_id)
+
+    assert mock_response.json.call_count == 1
+    assert case.id == test_id

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import json
 import sys
+
+import magic
 import os
 import warnings
 import json
 import magic
 import requests
 from requests.auth import AuthBase
+
+from thehive4py.models import CaseHelper
 
 
 class BearerAuth(AuthBase):
@@ -47,6 +52,9 @@ class TheHiveApi:
             self.auth = BearerAuth(self.principal)
 
         self.cert = cert
+
+        # Create a CaseHelper instance
+        self.case = CaseHelper(self)
 
     def __find_rows(self, find_url, **attributes):
         """

--- a/thehive4py/exceptions.py
+++ b/thehive4py/exceptions.py
@@ -1,0 +1,7 @@
+class TheHiveException(Exception):
+    """Base class for TheHive exceptions"""
+    pass
+
+
+class CaseException(TheHiveException):
+    pass

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -91,7 +91,17 @@ class CaseHelper:
         self._thehive = thehive
 
     def __call__(self, id):
-        return self._thehive.get_case(id)
+        response = self._thehive.get_case(id)
+
+        if response.status_code == 200:
+            data = response.json()
+            case = Case(json=data)
+
+            # Add attributes that are not added by the constructor
+            case.id = data['id']
+            case.owner = data['owner']
+
+            return case
 
     def create(self, title, description, **kwargs):
         case = Case(title=title, description=description, **kwargs)

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -105,7 +105,9 @@ class CaseHelper:
 
     def create(self, title, description, **kwargs):
         case = Case(title=title, description=description, **kwargs)
-        return self._thehive.create_case(case)
+        response = self._thehive.create_case(case)
+        if response.status_code == 201:
+            return self(response.json()['id'])
 
 
 class CaseTask(JSONSerializable):

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -87,13 +87,26 @@ class Case(JSONSerializable):
 
 
 class CaseHelper:
+    """
+    Provides helper methods for interacting with instances of the Case class.
+    """
     def __init__(self, thehive):
+        """
+        Initialize a CaseHelper instance.
+        :param thehive: A TheHiveApi instance.
+
+        """
         self._thehive = thehive
 
     def __call__(self, id):
+        """
+        Return an instance of Case with the given case ID.
+        :param id: ID of a case to retrieve.
+
+        """
         response = self._thehive.get_case(id)
 
-        if response.status_code == 200:
+        if self.status_ok(response.status_code):
             data = response.json()
             case = Case(json=data)
 
@@ -104,10 +117,25 @@ class CaseHelper:
             return case
 
     def create(self, title, description, **kwargs):
+        """
+        Create an instance of the Case class.
+        :param title: Case title.
+        :param description: Case description.
+        :param kwargs: Additional arguments.
+
+        :return: The created instance.
+
+        """
         case = Case(title=title, description=description, **kwargs)
         response = self._thehive.create_case(case)
-        if response.status_code == 201:
+        if self.status_ok(response.status_code):
             return self(response.json()['id'])
+
+    @staticmethod
+    def status_ok(status_code):
+        """Check whether a status code is OK"""
+        OK_STATUS_CODES = [200, 201]
+        return status_code in OK_STATUS_CODES
 
 
 class CaseTask(JSONSerializable):

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -86,6 +86,18 @@ class Case(JSONSerializable):
                 self.tasks.append(CaseTask(json=task))
 
 
+class CaseHelper:
+    def __init__(self, thehive):
+        self._thehive = thehive
+
+    def __call__(self, id):
+        return self._thehive.get_case(id)
+
+    def create(self, title, description, **kwargs):
+        case = Case(title=title, description=description, **kwargs)
+        return self._thehive.create_case(case)
+
+
 class CaseTask(JSONSerializable):
 
     def __init__(self, **attributes):

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import json
-import time
-import os
-import magic
 import base64
+import json
+import os
+import time
 
+import magic
+import requests
 from future.utils import raise_with_traceback
+
+from thehive4py.exceptions import TheHiveException
 
 
 class CustomJsonEncoder(json.JSONEncoder):
@@ -105,6 +108,10 @@ class CaseHelper:
 
         """
         response = self._thehive.get_case(id)
+
+        # Check for failed authentication
+        if response.status_code == requests.codes.unauthorized:
+            raise TheHiveException("Authentication failed")
 
         if self.status_ok(response.status_code):
             data = response.json()


### PR DESCRIPTION
I’ve added a helper class for interacting with cases as a higher level. It wraps the existing get_case and create_case methods and in both cases returns a Case instance rather than a requests Response instance. These methods have not been touched to backwards compatibility should not be affected.

There is a sample file included (test-case-create__case-helper.py) which can be compared with test-case-create.py to show how the usage changes.

The next step would be to wrap some of the other methods, e.g. to make it easier to work with case tasks, but I’ll wait for some feedback on this approach before going further.

It looks like there are some duplicated commits - I originally forked from master, and then realised I should have forked from develop, and when I tried to rebase against develop I messed something up. Sorry about that.