### PR TITLE
Added a method to update a case.

### DIFF
--- a/samples/test-case-update.py
+++ b/samples/test-case-update.py
@@ -1,0 +1,23 @@
+from thehive4py.api import TheHiveApi
+
+
+thehive = TheHiveApi('http://127.0.0.1:9000', 'username', 'password', {'http': '', 'https': ''})
+
+# Create a new case
+case = thehive.case.create(title='From TheHive4Py', description='N/A', tlp=3, flag=True,
+                           tags=['TheHive4Py', 'sample'], tasks=[])
+
+# Save the new case's ID for later use
+case_id = case.id
+
+# Change some attributes of the new case
+case.tlp = 1
+case.severity = 1
+case.flag = False
+
+# Update the case
+thehive.update_case(case)
+
+# Retrieve the case from the server and check the updated values
+new_case = thehive.case(case_id)
+print("Case ID {}\nTLP: {}, Severity: {}".format(new_case.id, new_case.tlp, new_case.severity))

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -97,6 +97,26 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             sys.exit("Error: {}".format(e))
 
+    def update_case(self, case):
+        """
+        Update a case.
+        :param case: The case to update. The case's `id` determines which case to update.
+        :return:
+        """
+        req = self.url + "/api/case/{}".format(case.id)
+
+        # Choose which attributes to send
+        update_keys = [
+            'title', 'description', 'severity', 'startDate', 'owner', 'flag', 'tlp', 'tags', 'resolutionStatus',
+            'impactStatus', 'summary', 'endDate', 'metrics'
+        ]
+        data = {k: v for k, v in case.__dict__.items() if k in update_keys}
+
+        try:
+            return requests.patch(req, headers={'Content-Type': 'application/json'}, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
+        except requests.exceptions.RequestException:
+            sys.exit(1)
+
     def create_case_task(self, case_id, case_task):
 
         """


### PR DESCRIPTION
Added a method to update a case. I thought this might have been better as a method on the Case class (e.g. case.update()) but the Case model class doesn't have a reference to the API client so it can't make that call. This is the simplest way I can see to add this functionality right now.

This addresses #5 