### PR TITLE
Allow for creation and removal of customFields

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -329,7 +329,6 @@ class TheHiveApi:
         """
         :param custom_field: TheHive custom field
         :type customfield: CustomField defined in models.py
-        :return: TheHive custom field
         :rtype: json
         """
 
@@ -383,8 +382,7 @@ class TheHiveApi:
 
         """
         :param fieldId: Custom field Id to delete
-        :return: response
-        :rtype: json
+        :rtype: bool
         """
 	
 	req = self.url + "/api/list/{}".format(fieldId)

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -324,6 +324,82 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             sys.exit("Error: {}".format(e))
     
+    def create_custom_field(self, custom_field):
+
+        """
+        :param custom_field: TheHive custom field
+        :type customfield: CustomField defined in models.py
+        :return: TheHive custom field
+        :rtype: json
+        """
+
+        req = self.url + "/api/list/custom_fields/_exists"
+
+	data = {
+	    "key": "reference",
+            "value": custom_field.reference   
+	}
+        
+        try:
+            response = requests.post(req, headers={'Content-Type': 'application/json'}, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
+	    json_response = response.json()
+
+            if response.status_code == 200 and len(json_response) > 0:
+                exists = response.json()
+            else:
+                sys.exit("Error: {}".format("Unable to determine if custom field exists."))
+
+        except requests.exceptions.RequestException as e:
+            sys.exit("Error: {}".format(e))
+        
+	if exists['found'] == True:
+	    sys.exit("Cannot create custom field. The custom field reference already exists.")
+        else:
+	    req = self.url + "/api/list/custom_fields"
+
+            data = {
+                "value": {
+                    "name": custom_field.name,
+                    "reference": custom_field.reference,
+                    "description": custom_field.description,
+                    "type": custom_field.type,
+                    "options": custom_field.options 
+                }
+            }	
+
+            try:
+                response = requests.post(req, headers={'Content-Type': 'application/json'}, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
+                json_response = response.json()
+
+                if response.status_code == 200 and len(json_response) > 0:
+                    return response.json()
+                else:
+                    sys.exit("Error: {}".format("Unable to create custom field."))
+
+            except requests.exceptions.RequestException as e:
+                sys.exit("Error: {}".format(e))
+
+    def delete_custom_field(self, fieldId):
+
+        """
+        :param fieldId: Custom field Id to delete
+        :return: response
+        :rtype: json
+        """
+	
+	req = self.url + "/api/list/{}".format(fieldId)
+
+        try:
+            response = requests.delete(req, proxies=self.proxies, auth=self.auth, verify=self.cert)
+
+            if response.status_code == 200 or response.status_code == 204:
+                return True
+            else:
+                sys.exit("Error: {}".format("Error when attempting to remove custom field."))
+ 
+        except requests.exceptions.RequestException as e:
+            sys.exit("Error: {}".format(e))       
+
     def create_alert(self, alert):
 
         """

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -218,6 +218,19 @@ class CaseObservable(JSONSerializable):
             self.data = data
 
 
+class CaseCustomField(JSONSerializable):
+
+    def __init__(self, **attributes):
+        if attributes.get('json', False):
+            attributes = attributes['json']
+
+        self.name = self.attr(attributes, 'name', None, 'Missing custom field name')
+        self.reference = self.attr(attributes, 'reference', None, 'Missing custom field reference')
+        self.description = self.attr(attributes, 'description', None, 'Missing custom field description')
+        self.type = self.attr(attributes, 'type', None, 'Missing custom field type')
+        self.options = attributes.get('options', [])
+
+
 class Alert(JSONSerializable):
     def __init__(self, **attributes):
         if attributes.get('json', False):


### PR DESCRIPTION
This PR aims to simplify programmatic generation of Custom fields.

* Added CaseCustomField model in models.py
* Adds method *create_custom_field* to add custom fields - Calls the _exists API first to ensure that the custom field reference does not already exist. 
* Adds method *delete_custom_field* to facilitate deletion of custom fields using the Id of the custom field