### PR TITLE
Added missing attributes to the Case class.

### DIFF
--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -98,6 +98,15 @@ class Case(JSONSerializable):
         self.metrics = attributes.get('metrics', defaults['metrics'])
         self.customFields = attributes.get('customFields', defaults['customFields'])
         self.template = attributes.get('template', defaults['template'])
+        self.caseId = attributes.get('caseId', None)
+        self.createdAt = attributes.get('createdAt', None)
+        self.createdBy = attributes.get('createdBy', None)
+        self.id = attributes.get('id', None)
+        self.owner = attributes.get('owner', None)
+        self.status = attributes.get('status', None)
+        self.updatedAt = attributes.get('updatedAt', None)
+        self.updatedBy = attributes.get('updatedBy', None)
+        self.user = attributes.get('user', None)
 
         tasks = attributes.get('tasks', defaults['tasks'])
         self.tasks = []
@@ -138,10 +147,6 @@ class CaseHelper:
         if self.status_ok(response.status_code):
             data = response.json()
             case = Case(json=data)
-
-            # Add attributes that are not added by the constructor
-            case.id = data['id']
-            case.owner = data['owner']
 
             return case
 


### PR DESCRIPTION
The Case class's constructor did not add all attributes present in the JSON data returned from the API. For example, the `id` and `caseId`. You can now do:

```
case = thehive.case('some_case_id')
print(case.id)
print(case.caseId)  # The ID as shown in the web UI
print(case.status)
print(case.owner)
```