### PR TITLE
Support for Creating and Deleting Custom Fields

### DIFF
--- a/samples/test-custom-field-create-delete.py
+++ b/samples/test-custom-field-create-delete.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import time
+from thehive4py.api import TheHiveApi
+from thehive4py.models import CustomFieldHelper
+
+api = TheHiveApi('http://127.0.0.1:9000', 'api-key')
+
+string_custom_field = CustomFieldHelper.create_new_field(
+    'string',
+    'Test String Custom Field',
+    value=['First Option', 'Second Option', 'Third Option'],
+    reference='testStringField',
+    description='This is the description for the test string custom field')
+
+print("Creating a string custom field")
+creation_result = api.create_custom_field(string_custom_field)
+
+if creation_result:
+    print("ID: {}".format(creation_result))
+    print("Sleeping for 30 seconds. Go check your custom fields for {}".format(string_custom_field['reference']))
+    time.sleep(30)
+else:
+    print("could not create string custom field")
+    exit()
+
+print("Removing a string custom field")
+deletion_result = api.delete_custom_field(creation_result)
+
+if deletion_result:
+    print("Deleted string custom field with ID {}".format(creation_result))
+else:
+    print("Could not delete string custom field with ID {}".format(creation_result))
+
+
+boolean_custom_field = CustomFieldHelper.create_new_field(
+        "boolean",
+        "Was it bad?",
+        reference="badPreference",
+        description="Tell me if it was bad or not")
+
+print("")
+print("Creating a boolean custom field")
+creation_result = api.create_custom_field(boolean_custom_field)
+
+if creation_result:
+    print("ID: {}".format(creation_result))
+    print("Sleeping for 30 seconds. Go check your custom fields for {}".format(boolean_custom_field['reference']))
+    time.sleep(30)
+else:
+    print("could not create boolean custom field")
+    exit()
+
+print("Removing a boolean custom field")
+deletion_result = api.delete_custom_field(creation_result)
+
+if deletion_result:
+    print("Deleted boolean custom field with ID {}".format(creation_result))
+else:
+    print("Could not delete boolean custom field with ID {}".format(creation_result))

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -315,6 +315,81 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             sys.exit("Error: {}".format(e))
     
+    def create_custom_field(self, custom_field):
+
+        """
+        :param custom_field: TheHive custom field
+        :type customfield: CustomField defined in models.py
+        :rtype: json
+        """
+
+        req = self.url + "/api/list/custom_fields/_exists"
+
+        data = {
+            "key": "reference",
+            "value": custom_field['reference']
+        }
+
+        try:
+            response = requests.post(req, headers={'Content-Type': 'application/json'}, json=data,
+                                     proxies=self.proxies, auth=self.auth, verify=self.cert)
+            json_response = response.json()
+
+            if response.status_code == 200 and len(json_response) > 0:
+                exists = response.json()
+            else:
+                sys.exit("Error: {}".format("Unable to determine if custom field exists."))
+
+        except requests.exceptions.RequestException as e:
+            sys.exit("Error: {}".format(e))
+
+        if exists['found']:
+            sys.exit("Cannot create custom field. The custom field reference already exists.")
+        else:
+            req = self.url + "/api/list/custom_fields"
+
+            data = {
+                "value": {
+                    "name": custom_field['name'],
+                    "reference": custom_field['reference'],
+                    "description": custom_field['description'],
+                    "type": custom_field['type'],
+                    "options": custom_field['options']
+                }
+            }
+
+            try:
+                response = requests.post(req, headers={'Content-Type': 'application/json'}, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
+                json_response = response.json()
+
+                if response.status_code == 200 and len(json_response) > 0:
+                    return response.json()
+                else:
+                    sys.exit("Error: {}".format("Unable to create custom field."))
+
+            except requests.exceptions.RequestException as e:
+                sys.exit("Error: {}".format(e))
+
+    def delete_custom_field(self, fieldId):
+
+        """
+        :param fieldId: Custom field Id to delete
+        :rtype: bool
+        """
+
+        req = self.url + "/api/list/{}".format(fieldId)
+
+        try:
+            response = requests.delete(req, proxies=self.proxies, auth=self.auth, verify=self.cert)
+
+            if response.status_code == 200 or response.status_code == 204:
+                return True
+            else:
+                sys.exit("Error: {}".format("Error when attempting to remove custom field."))
+
+        except requests.exceptions.RequestException as e:
+            sys.exit("Error: {}".format(e))
+
     def create_alert(self, alert):
 
         """

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -38,6 +38,17 @@ class CustomFieldHelper(object):
     def __init__(self):
         self.fields = {}
 
+    @staticmethod
+    def create_new_field(type, name, value=[], reference='', description=''):
+        custom_field = dict()
+        custom_field['name'] = name
+        custom_field['type'] = type
+        custom_field['options'] = value
+        custom_field['reference'] = reference
+        custom_field['description'] = description
+
+        return custom_field
+
     def __add_field(self, type, name, value):
         custom_field = dict()
         custom_field['order'] = len(self.fields)


### PR DESCRIPTION
The new CustomFieldHelper is useful for adding a custom field(s) to a case or case template, but cannot be used to create a new custom field in TheHive. There are several fields missing such as reference, options, and description - all of which are required fields in TheHive GUI. This PR provides the ability programmatically create (or delete) Custom Fields. This feature is useful for deploying TheHive in multiple environments and wanting to utilize a standardized naming convention.

This PR adds the following support:
* Adds `create_custom_field` and `delete_custom_field` methods to TheHive4py API
* Adds a static method named `create_new_field` to CustomFieldHelper - returns a dict that can be passed to create_custom_field.
* Added example file `test-custom-field-create-delete` to demonstrate adding and deleting custom fields using the methods above.