### PR TITLE
fix get_case_observables method

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -233,14 +233,16 @@ class TheHiveApi:
         }
 
         # Add body
-        criteria = [Parent('case', Id(case_id)), Eq('status', 'Ok')]
+        parent_criteria = Parent('case', Id(case_id))
 
         # Append the custom query if specified
         if "query" in attributes:
-            criteria.append(attributes["query"])
+            criteria = And(parent_criteria, attributes["query"])
+        else:
+            criteria = parent_criteria
 
         data = {
-            "query": And(criteria)
+            "query": criteria
         }
 
         try:


### PR DESCRIPTION
With the most recent version of TheHive4Py, trying to retrieve observables programmatically via the get_case_observables method was throwing the following error:

```
{u'message': u'JsResultException(errors:List((,List(JsonValidationError(List(Invalid query: unexpected [{"_parent":{"_type":"case","_query":{"_id":"AWA9SlYM_XlqkMKDzIB0"}}},{"_value":"Ok","_field":"status"}]),WrappedArray())))))', u'type': u'play.api.libs.json.JsResultException'}
```

I updated the code using the same structure present in the get_case_tasks method.